### PR TITLE
feat(models): add destination models & repository

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,122 +1,137 @@
+// MAD201-01 Assignment 1
+// Student: Darshilkumar Karkar
+// Student ID: A00203357
+
+// Description: App entry point, routes, and main scaffold.
+
 import 'package:flutter/material.dart';
+import 'models/tourist_destination.dart';
+import 'models/cultural_destination.dart';
+import 'repositories/destination_repository.dart';
+import 'state/travel_app_model.dart';
+import 'state/travel_app_state.dart';
+import 'screens/home_screen.dart';
+import 'screens/details_screen.dart';
+import 'screens/profile_screen.dart';
+import 'screens/settings_screen.dart';
+import 'screens/about_screen.dart';
+import 'screens/bookings_screen.dart';
 
 void main() {
-  runApp(const MyApp());
+  final initial = [
+    TouristDestination(
+      id: 'paris',
+      name: 'Eiffel Tower',
+      country: 'France',
+      description: 'Iconic iron tower with panoramic views of Paris.',
+      imageUrl: 'assets/images/paris.jpg',
+      rating: 4.7,
+    ),
+    CulturalDestination(
+      id: 'asakusa',
+      name: 'Asakusa',
+      country: 'Japan',
+      description: 'Historic district with Senso-ji Temple and street food.',
+      imageUrl: 'assets/images/tokyo.jpg',
+      famousFood: 'Sushi & Tempura',
+    ),
+    TouristDestination(
+      id: 'nyc',
+      name: 'Times Square',
+      country: 'USA',
+      description: 'Busy tourist area with lights and theaters.',
+      imageUrl: 'assets/images/nyc.jpg',
+      rating: 4.0,
+    ),
+  ];
+
+  final repo = DestinationRepository(initial);
+  final profile = UserProfile(name: 'Your Full Name', travelerLevel: 'Novice', profileImageUrl: 'assets/images/profile_placeholder.png');
+  final model = TravelAppModel(repository: repo, profile: profile);
+
+  runApp(TravelAppState(notifier: model, child: TravelApp()));
 }
 
-class MyApp extends StatelessWidget {
-  const MyApp({super.key});
-
-  // This widget is the root of your application.
+class TravelApp extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
-    return MaterialApp(
-      title: 'Flutter Demo',
-      theme: ThemeData(
-        // This is the theme of your application.
-        //
-        // TRY THIS: Try running your application with "flutter run". You'll see
-        // the application has a purple toolbar. Then, without quitting the app,
-        // try changing the seedColor in the colorScheme below to Colors.green
-        // and then invoke "hot reload" (save your changes or press the "hot
-        // reload" button in a Flutter-supported IDE, or press "r" if you used
-        // the command line to start the app).
-        //
-        // Notice that the counter didn't reset back to zero; the application
-        // state is not lost during the reload. To reset the state, use hot
-        // restart instead.
-        //
-        // This works for code too, not just values: Most code changes can be
-        // tested with just a hot reload.
-        colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
-      ),
-      home: const MyHomePage(title: 'Flutter Demo Home Page'),
+    final model = TravelAppState.of(context);
+    return AnimatedBuilder(
+      animation: model,
+      builder: (context, _) {
+        return MaterialApp(
+          title: 'MAD201 Travel App',
+          theme: ThemeData.light(),
+          darkTheme: ThemeData.dark(),
+          themeMode: model.themeMode,
+          initialRoute: '/',
+          routes: {
+            '/': (ctx) => MainScaffold(),
+            '/details': (ctx) => DetailsScreen(),
+            '/profile': (ctx) => ProfileScreen(),
+            '/settings': (ctx) => SettingsScreen(),
+            '/about': (ctx) => AboutScreen(),
+            '/bookings': (ctx) => BookingsScreen(),
+          },
+        );
+      },
     );
   }
 }
 
-class MyHomePage extends StatefulWidget {
-  const MyHomePage({super.key, required this.title});
-
-  // This widget is the home page of your application. It is stateful, meaning
-  // that it has a State object (defined below) that contains fields that affect
-  // how it looks.
-
-  // This class is the configuration for the state. It holds the values (in this
-  // case the title) provided by the parent (in this case the App widget) and
-  // used by the build method of the State. Fields in a Widget subclass are
-  // always marked "final".
-
-  final String title;
-
+class MainScaffold extends StatefulWidget {
   @override
-  State<MyHomePage> createState() => _MyHomePageState();
+  _MainScaffoldState createState() => _MainScaffoldState();
 }
 
-class _MyHomePageState extends State<MyHomePage> {
-  int _counter = 0;
+class _MainScaffoldState extends State<MainScaffold> {
+  int _selectedIndex = 0;
 
-  void _incrementCounter() {
-    setState(() {
-      // This call to setState tells the Flutter framework that something has
-      // changed in this State, which causes it to rerun the build method below
-      // so that the display can reflect the updated values. If we changed
-      // _counter without calling setState(), then the build method would not be
-      // called again, and so nothing would appear to happen.
-      _counter++;
-    });
-  }
+  final List<Widget> _pages = [HomeScreen(), BookingsScreen(), ProfileScreen()];
+
+  void _onItemTapped(int index) => setState(() => _selectedIndex = index);
 
   @override
   Widget build(BuildContext context) {
-    // This method is rerun every time setState is called, for instance as done
-    // by the _incrementCounter method above.
-    //
-    // The Flutter framework has been optimized to make rerunning build methods
-    // fast, so that you can just rebuild anything that needs updating rather
-    // than having to individually change instances of widgets.
     return Scaffold(
-      appBar: AppBar(
-        // TRY THIS: Try changing the color here to a specific color (to
-        // Colors.amber, perhaps?) and trigger a hot reload to see the AppBar
-        // change color while the other colors stay the same.
-        backgroundColor: Theme.of(context).colorScheme.inversePrimary,
-        // Here we take the value from the MyHomePage object that was created by
-        // the App.build method, and use it to set our appbar title.
-        title: Text(widget.title),
-      ),
-      body: Center(
-        // Center is a layout widget. It takes a single child and positions it
-        // in the middle of the parent.
-        child: Column(
-          // Column is also a layout widget. It takes a list of children and
-          // arranges them vertically. By default, it sizes itself to fit its
-          // children horizontally, and tries to be as tall as its parent.
-          //
-          // Column has various properties to control how it sizes itself and
-          // how it positions its children. Here we use mainAxisAlignment to
-          // center the children vertically; the main axis here is the vertical
-          // axis because Columns are vertical (the cross axis would be
-          // horizontal).
-          //
-          // TRY THIS: Invoke "debug painting" (choose the "Toggle Debug Paint"
-          // action in the IDE, or press "p" in the console), to see the
-          // wireframe for each widget.
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: <Widget>[
-            const Text('You have pushed the button this many times:'),
-            Text(
-              '$_counter',
-              style: Theme.of(context).textTheme.headlineMedium,
+      appBar: AppBar(title: Text('Travel App')),
+      drawer: Drawer(
+        child: ListView(
+          children: [
+            DrawerHeader(child: Text('Travel App')),
+            ListTile(
+              leading: Icon(Icons.settings),
+              title: Text('Settings'),
+              onTap: () {
+                Navigator.pop(context);
+                Navigator.pushNamed(context, '/settings');
+              },
+            ),
+            ListTile(
+              leading: Icon(Icons.help),
+              title: Text('Help'),
+              onTap: () {
+                Navigator.pop(context);
+                ScaffoldMessenger.of(context).showSnackBar(SnackBar(content: Text('Help: contact your TA or instructor.')));
+              },
+            ),
+            ListTile(
+              leading: Icon(Icons.info),
+              title: Text('About'),
+              onTap: () {
+                Navigator.pop(context);
+                Navigator.pushNamed(context, '/about');
+              },
             ),
           ],
         ),
       ),
-      floatingActionButton: FloatingActionButton(
-        onPressed: _incrementCounter,
-        tooltip: 'Increment',
-        child: const Icon(Icons.add),
-      ), // This trailing comma makes auto-formatting nicer for build methods.
+      body: IndexedStack(index: _selectedIndex, children: _pages),
+      bottomNavigationBar: BottomNavigationBar(
+        currentIndex: _selectedIndex,
+        onTap: _onItemTapped,
+        items: [BottomNavigationBarItem(icon: Icon(Icons.home), label: 'Home'), BottomNavigationBarItem(icon: Icon(Icons.book), label: 'Bookings'), BottomNavigationBarItem(icon: Icon(Icons.person), label: 'Profile')],
+      ),
     );
   }
 }

--- a/lib/models/cultural_destination.dart
+++ b/lib/models/cultural_destination.dart
@@ -1,10 +1,14 @@
-/// MAD201-01 Assignment 1
-/// Darshilkumar Karkar / A00203357
+// MAD201-01 Assignment 1
+// Student: Darshilkumar Karkar
+// Student ID: A00203357
+// Description: CulturalDestination extends Destination with famousFood.
 
 import 'destination.dart';
 
+/// Cultural destination notable for local food.
 class CulturalDestination extends Destination {
-  String famousFood;
+  final String famousFood;
+
   CulturalDestination({
     required String id,
     required String name,
@@ -15,12 +19,12 @@ class CulturalDestination extends Destination {
     bool isFavorite = false,
     bool isVisited = false,
   }) : super(
-         id: id,
-         name: name,
-         country: country,
-         description: description,
-         imageUrl: imageUrl,
-         isFavorite: isFavorite,
-         isVisited: isVisited,
-       );
+          id: id,
+          name: name,
+          country: country,
+          description: description,
+          imageUrl: imageUrl,
+          isFavorite: isFavorite,
+          isVisited: isVisited,
+        );
 }

--- a/lib/models/destination.dart
+++ b/lib/models/destination.dart
@@ -1,13 +1,29 @@
-/// MAD201-01 Assignment 1
-/// Darshilkumar Karkar / A00203357
+// MAD201-01 Assignment 1
+// Student: Darshilkumar Karkar
+// Student ID: A00203357
+// Description: Base Destination model for MAD201 assignment.
+
 /// Represents a travel destination.
 abstract class Destination {
+  /// Unique id.
   final String id;
+
+  /// Name (e.g., Paris).
   final String name;
+
+  /// Country (e.g., France).
   final String country;
+
+  /// Detailed description.
   final String description;
+
+  /// Asset path or network URL to image.
   final String imageUrl;
+
+  /// Favorite flag.
   bool isFavorite;
+
+  /// Visited flag.
   bool isVisited;
 
   Destination({
@@ -20,13 +36,13 @@ abstract class Destination {
     this.isVisited = false,
   });
 
+  /// Toggle favorite flag.
   void toggleFavorite() {
     isFavorite = !isFavorite;
   }
 
+  /// Mark as visited.
   void markVisited() {
     isVisited = true;
   }
-
-  String shortLabel() => '$name, $country';
 }

--- a/lib/models/tourist_destination.dart
+++ b/lib/models/tourist_destination.dart
@@ -1,9 +1,14 @@
-/// MAD201-01 Assignment 1
-/// Darshilkumar Karkar / A00203357
+// MAD201-01 Assignment 1
+// Student: Darshilkumar Karkar
+// Student ID: A00203357
+// Description: TouristDestination extends Destination with rating.
+
 import 'destination.dart';
 
+/// Tourist destination with a rating.
 class TouristDestination extends Destination {
   double rating;
+
   TouristDestination({
     required String id,
     required String name,
@@ -14,12 +19,12 @@ class TouristDestination extends Destination {
     bool isFavorite = false,
     bool isVisited = false,
   }) : super(
-         id: id,
-         name: name,
-         country: country,
-         description: description,
-         imageUrl: imageUrl,
-         isFavorite: isFavorite,
-         isVisited: isVisited,
-       );
+          id: id,
+          name: name,
+          country: country,
+          description: description,
+          imageUrl: imageUrl,
+          isFavorite: isFavorite,
+          isVisited: isVisited,
+        );
 }

--- a/lib/repositories/destination_repository.dart
+++ b/lib/repositories/destination_repository.dart
@@ -1,0 +1,47 @@
+// MAD201-01 Assignment 1
+// Student: Darshilkumar Karkar
+// Student ID: A00203357
+// Description: In-memory destination repository.
+
+import '../models/destination.dart';
+
+class DestinationRepository {
+  final List<Destination> _destinations = [];
+
+  DestinationRepository([List<Destination>? initial]) {
+    if (initial != null) {
+      _destinations.addAll(initial);
+    }
+  }
+
+  /// Returns unmodifiable list of all destinations.
+  List<Destination> getAllDestinations() => List.unmodifiable(_destinations);
+
+  /// Add a destination.
+  void addDestination(Destination d) => _destinations.add(d);
+
+  /// Get by id. Returns null if not found.
+  Destination? getById(String id) {
+    try {
+      return _destinations.firstWhere((d) => d.id == id);
+    } catch (e) {
+      return null;
+    }
+  }
+
+  /// Toggle favorite for id.
+  void toggleFavorite(String id) {
+    final d = getById(id);
+    if (d != null) d.toggleFavorite();
+  }
+
+  /// Mark visited for id.
+  void markVisited(String id) {
+    final d = getById(id);
+    if (d != null) d.markVisited();
+  }
+
+  /// Return set of visited countries.
+  Set<String> getVisitedCountries() =>
+      _destinations.where((d) => d.isVisited).map((d) => d.country).toSet();
+}

--- a/lib/screens/about_screen.dart
+++ b/lib/screens/about_screen.dart
@@ -1,0 +1,19 @@
+// MAD201-01 Assignment 1
+// Student: Darshilkumar Karkar
+// Student ID: A00203357
+// Description: Static about screen.
+
+import 'package:flutter/material.dart';
+
+class AboutScreen extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('About')),
+      body: Padding(
+        padding: EdgeInsets.all(12),
+        child: Text('MAD201 Assignment 1 - Travel App\n\nDemonstrates Dart OOP, navigation, app-wide state, search/sort, dark mode, and returning data between screens.'),
+      ),
+    );
+  }
+}

--- a/lib/screens/bookings_screen.dart
+++ b/lib/screens/bookings_screen.dart
@@ -1,0 +1,13 @@
+// MAD201-01 Assignment 1
+// Student: Darshilkumar Karkar
+// Student ID: A00203357
+// Description: Bookings placeholder.
+
+import 'package:flutter/material.dart';
+
+class BookingsScreen extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(appBar: AppBar(title: Text('Bookings')), body: Center(child: Text('No bookings yet')));
+  }
+}

--- a/lib/screens/details_screen.dart
+++ b/lib/screens/details_screen.dart
@@ -1,0 +1,82 @@
+// MAD201-01 Assignment 1
+// Student: Darshilkumar Karkar
+// Student ID: A00203357
+// Description: Details screen showing full info and mark visited.
+
+import 'package:flutter/material.dart';
+import '../state/travel_app_state.dart';
+import '../widgets/visited_badge.dart';
+import '../models/destination.dart';
+import '../models/tourist_destination.dart';
+import '../models/cultural_destination.dart';
+
+class DetailsScreen extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    final model = TravelAppState.of(context);
+    final args = ModalRoute.of(context)!.settings.arguments;
+    if (args == null) {
+      return Scaffold(appBar: AppBar(title: Text('Details')), body: Center(child: Text('No destination provided')));
+    }
+    final String id = args as String;
+    final dest = model.getById(id);
+    if (dest == null) {
+      return Scaffold(appBar: AppBar(title: Text('Details')), body: Center(child: Text('Destination not found')));
+    }
+
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(dest.name),
+        actions: [
+          IconButton(icon: Icon(dest.isFavorite ? Icons.star : Icons.star_border), onPressed: () => model.toggleFavorite(dest.id)),
+        ],
+      ),
+      body: SingleChildScrollView(
+        child: Column(
+          children: [
+            Stack(
+              children: [
+                Image.asset(dest.imageUrl, width: double.infinity, height: 240, fit: BoxFit.cover),
+                if (dest.isVisited)
+                  Positioned(top: 12, right: 12, child: VisitedBadge()),
+              ],
+            ),
+            Padding(
+              padding: EdgeInsets.all(12),
+              child: Column(crossAxisAlignment: CrossAxisAlignment.start, children: [
+                Text(dest.name, style: Theme.of(context).textTheme.headline6),
+                SizedBox(height: 6),
+                Text(dest.country),
+                SizedBox(height: 12),
+                Text(dest.description),
+                SizedBox(height: 12),
+                if (dest is TouristDestination) Text('Rating: ${(dest as TouristDestination).rating} / 5'),
+                if (dest is CulturalDestination) Text('Famous food: ${(dest as CulturalDestination).famousFood}'),
+                SizedBox(height: 12),
+                Row(children: [
+                  ElevatedButton.icon(
+                    icon: Icon(Icons.check),
+                    label: Text(dest.isVisited ? 'Visited' : 'Mark as Visited'),
+                    onPressed: dest.isVisited
+                        ? null
+                        : () {
+                            model.markVisited(dest.id);
+                            // return id so previous screen can optionally handle it
+                            Navigator.pop(context, dest.id);
+                          },
+                  ),
+                  SizedBox(width: 10),
+                  OutlinedButton.icon(
+                    icon: Icon(dest.isFavorite ? Icons.star : Icons.star_border),
+                    label: Text(dest.isFavorite ? 'Favorited' : 'Add to Favorites'),
+                    onPressed: () => model.toggleFavorite(dest.id),
+                  )
+                ])
+              ]),
+            )
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -1,0 +1,95 @@
+// MAD201-01 Assignment 1
+// Student: Darshilkumar Karkar
+// Student ID: A00203357
+// Description: Home screen with search and sort.
+
+import 'package:flutter/material.dart';
+import '../state/travel_app_state.dart';
+import '../models/destination.dart';
+import '../widgets/destination_card.dart';
+import '../models/tourist_destination.dart';
+
+enum SortOption { name, country, rating }
+
+class HomeScreen extends StatefulWidget {
+  @override
+  _HomeScreenState createState() => _HomeScreenState();
+}
+
+class _HomeScreenState extends State<HomeScreen> {
+  String _query = '';
+  SortOption _sort = SortOption.name;
+
+  List<Destination> _filterAndSort(List<Destination> list) {
+    final q = _query.toLowerCase().trim();
+    var filtered = list.where((d) {
+      return d.name.toLowerCase().contains(q) || d.country.toLowerCase().contains(q);
+    }).toList();
+
+    switch (_sort) {
+      case SortOption.name:
+        filtered.sort((a, b) => a.name.compareTo(b.name));
+        break;
+      case SortOption.country:
+        filtered.sort((a, b) => a.country.compareTo(b.country));
+        break;
+      case SortOption.rating:
+        filtered.sort((a, b) {
+          double ar = (a is TouristDestination) ? (a as TouristDestination).rating : 0.0;
+          double br = (b is TouristDestination) ? (b as TouristDestination).rating : 0.0;
+          return br.compareTo(ar); // descending
+        });
+        break;
+    }
+    return filtered;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final model = TravelAppState.of(context);
+    final all = model.allDestinations;
+    final list = _filterAndSort(all);
+
+    return Scaffold(
+      body: SafeArea(
+        child: Column(
+          children: [
+            Padding(
+              padding: EdgeInsets.all(10),
+              child: TextField(
+                decoration: InputDecoration(prefixIcon: Icon(Icons.search), hintText: 'Search by name or country', border: OutlineInputBorder()),
+                onChanged: (v) => setState(() => _query = v),
+              ),
+            ),
+            Padding(
+              padding: EdgeInsets.symmetric(horizontal: 12),
+              child: Row(
+                children: [
+                  Text('Sort:'),
+                  SizedBox(width: 8),
+                  DropdownButton<SortOption>(
+                    value: _sort,
+                    items: [
+                      DropdownMenuItem(value: SortOption.name, child: Text('Name')),
+                      DropdownMenuItem(value: SortOption.country, child: Text('Country')),
+                      DropdownMenuItem(value: SortOption.rating, child: Text('Rating')),
+                    ],
+                    onChanged: (v) => setState(() => _sort = v ?? SortOption.name),
+                  ),
+                  Spacer(),
+                  Text('${list.length} destinations'),
+                ],
+              ),
+            ),
+            Expanded(
+              child: ListView.builder(
+                itemCount: list.length,
+                itemBuilder: (ctx, i) => DestinationCard(destination: list[i]),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/profile_screen.dart
+++ b/lib/screens/profile_screen.dart
@@ -1,0 +1,80 @@
+// MAD201-01 Assignment 1
+// Student: Darshilkumar Karkar
+// Student ID: A00203357
+// Description: Profile screen with tabs: Info, Visited, Stats.
+
+import 'package:flutter/material.dart';
+import '../state/travel_app_state.dart';
+
+class ProfileScreen extends StatefulWidget {
+  @override
+  _ProfileScreenState createState() => _ProfileScreenState();
+}
+
+class _ProfileScreenState extends State<ProfileScreen> with SingleTickerProviderStateMixin {
+  late TabController _tabController;
+
+  @override
+  void initState() {
+    _tabController = TabController(length: 3, vsync: this);
+    super.initState();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final model = TravelAppState.of(context);
+    final profile = model.profile;
+    final visited = model.allDestinations.where((d) => d.isVisited).toList();
+    final favCount = model.favoritesCount;
+    final visitedCountries = model.getVisitedCountries().length;
+
+    return Scaffold(
+      appBar: AppBar(
+        title: Text('Profile'),
+        bottom: TabBar(controller: _tabController, tabs: [Tab(text: 'Info'), Tab(text: 'Visited'), Tab(text: 'Stats')]),
+      ),
+      body: TabBarView(
+        controller: _tabController,
+        children: [
+          // Info
+          Padding(
+            padding: EdgeInsets.all(12),
+            child: Column(children: [
+              CircleAvatar(radius: 44, backgroundImage: AssetImage(profile.profileImageUrl)),
+              SizedBox(height: 12),
+              Text(profile.name, style: TextStyle(fontSize: 20)),
+              SizedBox(height: 6),
+              Text('Level: ${profile.travelerLevel}'),
+            ]),
+          ),
+
+          // Visited
+          ListView.builder(
+            itemCount: visited.length,
+            itemBuilder: (ctx, i) {
+              final d = visited[i];
+              return ListTile(
+                leading: Image.asset(d.imageUrl, width: 56, height: 56, fit: BoxFit.cover),
+                title: Text(d.name),
+                subtitle: Text(d.country),
+                onTap: () => Navigator.pushNamed(context, '/details', arguments: d.id),
+              );
+            },
+          ),
+
+          // Stats
+          Padding(
+            padding: EdgeInsets.all(12),
+            child: Column(crossAxisAlignment: CrossAxisAlignment.start, children: [
+              Text('Favorites: $favCount'),
+              SizedBox(height: 8),
+              Text('Visited destinations: ${visited.length}'),
+              SizedBox(height: 8),
+              Text('Visited countries: $visitedCountries'),
+            ]),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -1,0 +1,27 @@
+// MAD201-01 Assignment 1
+// Student: Darshilkumar Karkar
+// Student ID: A00203357
+// Description: Settings screen with dark mode toggle.
+
+import 'package:flutter/material.dart';
+import '../state/travel_app_state.dart';
+
+class SettingsScreen extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    final model = TravelAppState.of(context);
+    return Scaffold(
+      appBar: AppBar(title: Text('Settings')),
+      body: ListView(
+        children: [
+          SwitchListTile(
+            title: Text('Dark mode'),
+            value: model.themeMode == ThemeMode.dark,
+            onChanged: (v) => model.toggleTheme(),
+          ),
+          ListTile(title: Text('Other setting (placeholder)'), subtitle: Text('Add more here')),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/state/travel_app_model.dart
+++ b/lib/state/travel_app_model.dart
@@ -1,0 +1,65 @@
+// MAD201-01 Assignment 1
+// Student: Darshilkumar Karkar
+// Student ID: A00203357
+// Description: ChangeNotifier holding app-wide state.
+
+import 'package:flutter/material.dart';
+import '../repositories/destination_repository.dart';
+import '../models/destination.dart';
+
+class UserProfile {
+  String name;
+  String travelerLevel;
+  String profileImageUrl;
+
+  UserProfile({
+    required this.name,
+    this.travelerLevel = 'Novice',
+    required this.profileImageUrl,
+  });
+}
+
+class TravelAppModel extends ChangeNotifier {
+  final DestinationRepository repository;
+  UserProfile profile;
+  ThemeMode themeMode = ThemeMode.light;
+
+  TravelAppModel({required this.repository, required this.profile});
+
+  List<Destination> get allDestinations => repository.getAllDestinations();
+
+  Destination? getById(String id) => repository.getById(id);
+
+  void addDestination(Destination d) {
+    repository.addDestination(d);
+    notifyListeners();
+  }
+
+  void toggleFavorite(String id) {
+    repository.toggleFavorite(id);
+    notifyListeners();
+  }
+
+  void markVisited(String id) {
+    repository.markVisited(id);
+    notifyListeners();
+  }
+
+  Set<String> getVisitedCountries() => repository.getVisitedCountries();
+
+  int get favoritesCount =>
+      repository.getAllDestinations().where((d) => d.isFavorite).length;
+
+  int get visitedCount =>
+      repository.getAllDestinations().where((d) => d.isVisited).length;
+
+  void toggleTheme() {
+    themeMode = themeMode == ThemeMode.light ? ThemeMode.dark : ThemeMode.light;
+    notifyListeners();
+  }
+
+  void updateProfile(UserProfile p) {
+    profile = p;
+    notifyListeners();
+  }
+}

--- a/lib/state/travel_app_state.dart
+++ b/lib/state/travel_app_state.dart
@@ -1,0 +1,22 @@
+// MAD201-01 Assignment 1
+// Student: Darshilkumar Karkar
+// Student ID: A00203357
+// Description: InheritedNotifier wrapper to access TravelAppModel.
+
+import 'package:flutter/widgets.dart';
+import 'travel_app_model.dart';
+
+class TravelAppState extends InheritedNotifier<TravelAppModel> {
+  const TravelAppState({
+    Key? key,
+    required TravelAppModel notifier,
+    required Widget child,
+  }) : super(key: key, notifier: notifier, child: child);
+
+  static TravelAppModel of(BuildContext context) {
+    final widget =
+        context.dependOnInheritedWidgetOfExactType<TravelAppState>();
+    assert(widget != null, 'TravelAppState not found in context');
+    return widget!.notifier!;
+  }
+}

--- a/lib/widgets/destination_card.dart
+++ b/lib/widgets/destination_card.dart
@@ -1,0 +1,38 @@
+// MAD201-01 Assignment 1
+// Student: Darshilkumar Karkar
+// Student ID: A00203357
+// Description: List tile for destination.
+
+import 'package:flutter/material.dart';
+import '../models/destination.dart';
+import '../state/travel_app_state.dart';
+
+class DestinationCard extends StatelessWidget {
+  final Destination destination;
+
+  const DestinationCard({Key? key, required this.destination}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    final model = TravelAppState.of(context);
+    return Card(
+      margin: EdgeInsets.symmetric(vertical: 6, horizontal: 10),
+      child: ListTile(
+        leading: ClipRRect(
+          borderRadius: BorderRadius.circular(6),
+          child: Image.asset(destination.imageUrl, width: 72, height: 72, fit: BoxFit.cover),
+        ),
+        title: Text(destination.name),
+        subtitle: Text(destination.country),
+        trailing: IconButton(
+          icon: Icon(destination.isFavorite ? Icons.star : Icons.star_border),
+          onPressed: () => model.toggleFavorite(destination.id),
+        ),
+        onTap: () async {
+          final result = await Navigator.pushNamed(context, '/details', arguments: destination.id);
+          // result may be id of updated destination; model notifies so UI updates automatically
+        },
+      ),
+    );
+  }
+}

--- a/lib/widgets/visited_badge.dart
+++ b/lib/widgets/visited_badge.dart
@@ -1,0 +1,19 @@
+// MAD201-01 Assignment 1
+// Student: Darshilkumar Karkar
+// Student ID: A00203357
+// Description: Small "Visited" badge overlay.
+
+import 'package:flutter/material.dart';
+
+class VisitedBadge extends StatelessWidget {
+  const VisitedBadge({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+      decoration: BoxDecoration(color: Colors.black54, borderRadius: BorderRadius.circular(6)),
+      child: Text('Visited', style: TextStyle(color: Colors.white)),
+    );
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -58,9 +58,15 @@ flutter:
   uses-material-design: true
 
   # To add assets to your application, add an assets section, like this:
-  # assets:
-  #   - images/a_dot_burr.jpeg
-  #   - images/a_dot_ham.jpeg
+  flutter:
+  uses-material-design: true
+
+  assets:
+    - assets/images/paris.jpg
+    - assets/images/tokyo.jpg
+    - assets/images/nyc.jpg
+    - assets/images/profile_placeholder.png
+
 
   # An image asset can refer to one or more resolution-specific "variants", see
   # https://flutter.dev/to/resolution-aware-images


### PR DESCRIPTION
This PR adds the core data models:
- Destination (base)
- TouristDestination (rating)
- CulturalDestination (famousFood)
Also adds an in-memory DestinationRepository with methods:
- getAllDestinations()
- getById()
- toggleFavorite()
- markVisited()
- getVisitedCountries()

Docs and header comments included.